### PR TITLE
Properly handle missing .html file

### DIFF
--- a/emailit/api.py
+++ b/emailit/api.py
@@ -54,10 +54,11 @@ def construct_mail(recipients=None, context=None, template_base='emailit/email',
         subject = subject.replace('\n', '').replace('\r', '').strip()
         context['subject'] = subject
         try:
-            html = render_to_string(html_templates + ['emailit/empty.txt'], context)
-            html = premailer.transform(html, base_url=base_url)
+            html = render_to_string(html_templates, context)
         except TemplateDoesNotExist, e:
             html = ''
+        else:
+            html = premailer.transform(html, base_url=base_url)
         try:
             body = render_to_string(body_templates + ['emailit/empty.txt'], context)
         except TemplateDoesNotExist, e:


### PR DESCRIPTION
When no .html file is provided, the logic should not render `empty.txt`. Instead it should give up and set `html` to an empty string.

Currently empty string is passed to premailer causing `XMLSyntaxError` with `HTMLParser`.
